### PR TITLE
tracing, logging, decoupled vad, automatic gain control, pre-emphasis

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "jni/libfvad"]
-	path = jni/libfvad
-	url = git@github.com:dpirch/libfvad

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "jni/filter_audio"]
+	path = jni/filter_audio
+	url = git@github.com:irungentoo/filter_audio

--- a/README.md
+++ b/README.md
@@ -59,9 +59,12 @@ out the [documentation](https://azure.microsoft.com/en-us/services/cognitive-ser
 ```java
 SpeechPipeline pipeline = new SpeechPipeline.Builder()
     .setInputClass("com.pylon.spokestack.android.MicrophoneInput")
+    .addStageClass("com.pylon.spokestack.webrtc.AutomaticGainControl")
+    .addStageClass("com.pylon.spokestack.webrtc.VoiceActivityDetector")
     .addStageClass("com.pylon.spokestack.wakeword.WakewordTrigger")
     .addStageClass("com.pylon.spokestack.google.GoogleSpeechRecognizer")
     .setProperty("vad-fall-delay", 200)
+    .setProperty("pre-emphasis", 0.97)
     .setProperty("wake-words", "up,dog")
     .setProperty("wake-phrases", "up dog")
     .setProperty("wake-filter-path", "<tensorflow-lite-filter-path>")

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -4,19 +4,33 @@ include $(CLEAR_VARS)
 
 LOCAL_MODULE    := spokestack
 LOCAL_SRC_FILES := \
+	agc.cpp \
 	vad.cpp \
-	libfvad/src/signal_processing/division_operations.c \
-	libfvad/src/signal_processing/energy.c \
-	libfvad/src/signal_processing/get_scaling_square.c \
-	libfvad/src/signal_processing/resample_48khz.c \
-	libfvad/src/signal_processing/resample_by_2_internal.c \
-	libfvad/src/signal_processing/resample_fractional.c \
-	libfvad/src/signal_processing/spl_inl.c \
-	libfvad/src/vad/vad_core.c \
-	libfvad/src/vad/vad_filterbank.c \
-	libfvad/src/vad/vad_gmm.c \
-	libfvad/src/vad/vad_sp.c \
-	libfvad/src/fvad.c
+	filter_audio/other/complex_bit_reverse.c \
+	filter_audio/other/complex_fft.c \
+	filter_audio/other/copy_set_operations.c \
+	filter_audio/other/cross_correlation.c \
+	filter_audio/other/division_operations.c \
+	filter_audio/other/dot_product_with_scale.c \
+	filter_audio/other/downsample_fast.c \
+	filter_audio/other/energy.c \
+	filter_audio/other/get_scaling_square.c \
+	filter_audio/other/min_max_operations.c \
+	filter_audio/other/real_fft.c \
+	filter_audio/other/resample_by_2.c \
+	filter_audio/other/resample_by_2_internal.c \
+	filter_audio/other/resample_fractional.c \
+	filter_audio/other/resample_48khz.c \
+	filter_audio/other/spl_init.c \
+	filter_audio/other/spl_sqrt.c \
+	filter_audio/other/vector_scaling_operations.c \
+	filter_audio/vad/vad_core.c \
+	filter_audio/vad/vad_filterbank.c \
+	filter_audio/vad/vad_gmm.c \
+	filter_audio/vad/vad_sp.c \
+	filter_audio/vad/webrtc_vad.c \
+	filter_audio/agc/analog_agc.c \
+	filter_audio/agc/digital_agc.c
 
 include $(BUILD_SHARED_LIBRARY)
 

--- a/jni/Dev.mk
+++ b/jni/Dev.mk
@@ -13,19 +13,33 @@ clean:
 rebuild: clean all
 
 $(OUTDIR)/libspokestack.so: \
+	agc.cpp \
 	vad.cpp \
-	libfvad/src/signal_processing/division_operations.c \
-	libfvad/src/signal_processing/energy.c \
-	libfvad/src/signal_processing/get_scaling_square.c \
-	libfvad/src/signal_processing/resample_48khz.c \
-	libfvad/src/signal_processing/resample_by_2_internal.c \
-	libfvad/src/signal_processing/resample_fractional.c \
-	libfvad/src/signal_processing/spl_inl.c \
-	libfvad/src/vad/vad_core.c \
-	libfvad/src/vad/vad_filterbank.c \
-	libfvad/src/vad/vad_gmm.c \
-	libfvad/src/vad/vad_sp.c \
-	libfvad/src/fvad.c
+	filter_audio/other/complex_bit_reverse.c \
+	filter_audio/other/complex_fft.c \
+	filter_audio/other/copy_set_operations.c \
+	filter_audio/other/cross_correlation.c \
+	filter_audio/other/division_operations.c \
+	filter_audio/other/dot_product_with_scale.c \
+	filter_audio/other/downsample_fast.c \
+	filter_audio/other/energy.c \
+	filter_audio/other/get_scaling_square.c \
+	filter_audio/other/min_max_operations.c \
+	filter_audio/other/real_fft.c \
+	filter_audio/other/resample_by_2.c \
+	filter_audio/other/resample_by_2_internal.c \
+	filter_audio/other/resample_fractional.c \
+	filter_audio/other/resample_48khz.c \
+	filter_audio/other/spl_init.c \
+	filter_audio/other/spl_sqrt.c \
+	filter_audio/other/vector_scaling_operations.c \
+	filter_audio/vad/vad_core.c \
+	filter_audio/vad/vad_filterbank.c \
+	filter_audio/vad/vad_gmm.c \
+	filter_audio/vad/vad_sp.c \
+	filter_audio/vad/webrtc_vad.c \
+	filter_audio/agc/analog_agc.c \
+	filter_audio/agc/digital_agc.c
 
 %.so:
 	$(CC) $(CFLAGS) -o $@ $^

--- a/jni/agc.cpp
+++ b/jni/agc.cpp
@@ -1,0 +1,105 @@
+/****************************************************************************
+ *
+ * MODULE:  agc.cpp
+ * PURPOSE: webrtc automatic gain control (agc) jni wrapper
+ *
+ ***************************************************************************/
+/*-------------------[       Pre Include Defines       ]-------------------*/
+/*-------------------[      Library Include Files      ]-------------------*/
+#include <jni.h>
+#include <string.h>
+/*-------------------[      Project Include Files      ]-------------------*/
+#include "filter_audio/agc/include/gain_control.h"
+/*-------------------[      Macros/Constants/Types     ]-------------------*/
+/*-------------------[        Global Variables         ]-------------------*/
+/*-------------------[        Global Prototypes        ]-------------------*/
+/*-------------------[        Module Variables         ]-------------------*/
+static int32_t miclevel = 0;
+/*-------------------[        Module Prototypes        ]-------------------*/
+/*-------------------[         Implementation          ]-------------------*/
+/*-----------< FUNCTION: AutomaticGainControl_create >-----------------------
+// Purpose:    creates and configures a new webrtc agc component
+// Parameters: env               - java environment
+//             self              - java this reference
+//             rate              - sample rate, in Hz
+//             targetLeveldBFS   - target peak energy, in dB full scale
+//             compressionGaindB - dynamic range compression rate, in dB
+//             limiterEnable     - true to enable the agc's peak limiter
+// Returns:    pointer to the opaque agc instance if successful
+//             null otherwise
+---------------------------------------------------------------------------*/
+extern "C" JNIEXPORT
+jlong JNICALL Java_com_pylon_spokestack_webrtc_AutomaticGainControl_create(
+      JNIEnv*  env,
+      jobject  self,
+      jint     rate,
+      jint     targetLeveldBFS,
+      jint     compressionGaindB,
+      jboolean limiterEnable) {
+   // create and initialize the agc instance
+   void* agc = NULL;
+   int result = WebRtcAgc_Create(&agc);
+   if (result == 0) {
+      result = WebRtcAgc_Init(agc, 0, 100, kAgcModeFixedDigital, rate);
+      if (result == 0) {
+         // configure the agc
+         WebRtcAgc_config_t config; memset(&config, 0, sizeof(config));
+         config.targetLevelDbfs   = targetLeveldBFS;
+         config.limiterEnable     = limiterEnable ? kAgcTrue : kAgcFalse;
+         config.compressionGaindB = compressionGaindB;
+         result = WebRtcAgc_set_config(agc, config);
+      }
+      // if something went wrong, clean up
+      if (result != 0) {
+         WebRtcAgc_Free(agc);
+         agc = NULL;
+      }
+   }
+   return (jlong)agc;
+}
+/*-----------< FUNCTION: AutomaticGainControl_destroy >----------------------
+// Purpose:    releases agc resources
+// Parameters: env  - java environment
+//             self - java this reference
+//             agc  - agc handle returned by create()
+// Returns:    none
+---------------------------------------------------------------------------*/
+extern "C" JNIEXPORT
+void JNICALL Java_com_pylon_spokestack_webrtc_AutomaticGainControl_destroy(
+      JNIEnv* env,
+      jobject self,
+      jlong   agc) {
+   WebRtcAgc_Free((void*)agc);
+}
+/*-----------< FUNCTION: AutomaticGainControl_process >----------------------
+// Purpose:    processes an audio frame, applying gain as needed
+// Parameters: env    - java environment
+//             self   - java this reference
+//             agc    - agc handle returned by create()
+//             buffer - sample buffer (16-bit samples)
+//             length - size, in bytes, of the buffer
+// Returns:    1 if voiced speech was detected
+//             0 if not detected
+//             -1 on error
+---------------------------------------------------------------------------*/
+extern "C" JNIEXPORT
+jint JNICALL Java_com_pylon_spokestack_webrtc_AutomaticGainControl_process(
+      JNIEnv* env,
+      jobject self,
+      jlong   agc,
+      jobject buffer,
+      jint    length) {
+   int16_t* frame = (int16_t*)env->GetDirectBufferAddress(buffer);
+   uint8_t saturated = 0;
+   return WebRtcAgc_Process(
+      (void*)agc,
+      frame,
+      NULL,
+      length / 2,
+      frame,
+      NULL,
+      miclevel,
+      &miclevel,
+      0,
+      &saturated);
+}

--- a/jni/vad.cpp
+++ b/jni/vad.cpp
@@ -1,36 +1,83 @@
+/****************************************************************************
+ *
+ * MODULE:  vad.cpp
+ * PURPOSE: webrtc voice activity detector (vad) jni wrapper
+ *
+ ***************************************************************************/
+/*-------------------[       Pre Include Defines       ]-------------------*/
+/*-------------------[      Library Include Files      ]-------------------*/
 #include <jni.h>
-
-extern "C" {
-#  include "libfvad/include/fvad.h"
-}
-
-extern "C" JNIEXPORT jlong JNICALL
-Java_com_pylon_spokestack_libfvad_VADTrigger_create(
+/*-------------------[      Project Include Files      ]-------------------*/
+#include "filter_audio/vad/include/webrtc_vad.h"
+/*-------------------[      Macros/Constants/Types     ]-------------------*/
+/*-------------------[        Global Variables         ]-------------------*/
+/*-------------------[        Global Prototypes        ]-------------------*/
+/*-------------------[        Module Variables         ]-------------------*/
+/*-------------------[        Module Prototypes        ]-------------------*/
+/*-------------------[         Implementation          ]-------------------*/
+/*-----------< FUNCTION: VoiceActivityDetector_create >----------------------
+// Purpose:    creates and configures a new webrtc vad component
+// Parameters: env  - java environment
+//             self - java this reference
+//             mode - vad mode (0..3) in order of precision
+// Returns:    pointer to the opaque vad instance if successful
+//             null otherwise
+---------------------------------------------------------------------------*/
+extern "C" JNIEXPORT
+jlong JNICALL Java_com_pylon_spokestack_webrtc_VoiceActivityDetector_create(
       JNIEnv* env,
       jobject self,
-      jint    mode,
-      jint    rate) {
-   Fvad* vad = fvad_new();
-   fvad_set_mode(vad, mode);
-   fvad_set_sample_rate(vad, rate);
+      jint    mode) {
+   // create and initialize the vad instance
+   VadInst* vad = NULL;
+   int result = WebRtcVad_Create(&vad);
+   if (result == 0) {
+      result = WebRtcVad_Init(vad);
+      // configure the vad instance
+      if (result == 0)
+         result = WebRtcVad_set_mode(vad, mode);
+      // if something went wrong, cleanup
+      if (result != 0) {
+         WebRtcVad_Free(vad);
+         vad = NULL;
+      }
+   }
    return (jlong)vad;
 }
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_pylon_spokestack_libfvad_VADTrigger_destroy(
+/*-----------< FUNCTION: VoiceActivityDetector_destroy >---------------------
+// Purpose:    releases vad resources
+// Parameters: env  - java environment
+//             self - java this reference
+//             vad  - vad handle returned by create()
+// Returns:    none
+---------------------------------------------------------------------------*/
+extern "C" JNIEXPORT
+void JNICALL Java_com_pylon_spokestack_webrtc_VoiceActivityDetector_destroy(
       JNIEnv* env,
       jobject self,
       jlong   vad) {
-   fvad_free((Fvad*)vad);
+   WebRtcVad_Free((VadInst*)vad);
 }
-
-extern "C" JNIEXPORT jint JNICALL
-Java_com_pylon_spokestack_libfvad_VADTrigger_process(
+/*-----------< FUNCTION: VoiceActivityDetector_process >---------------------
+// Purpose:    processes an audio frame, detecting voiced speech
+// Parameters: env    - java environment
+//             self   - java this reference
+//             vad    - vad handle returned by create()
+//             rate   - sample rate, in Hz
+//             buffer - sample buffer (16-bit samples)
+//             length - size, in bytes, of the buffer
+// Returns:    1 if voiced speech was detected
+//             0 if not detected
+//             -1 on error
+---------------------------------------------------------------------------*/
+extern "C" JNIEXPORT
+jint JNICALL Java_com_pylon_spokestack_webrtc_VoiceActivityDetector_process(
       JNIEnv* env,
       jobject self,
       jlong   vad,
+      jint    rate,
       jobject buffer,
       jint    length) {
    int16_t* frame = (int16_t*)env->GetDirectBufferAddress(buffer);
-   return fvad_process((Fvad*)vad, frame, length / 2);
+   return WebRtcVad_Process((VadInst*)vad, rate, frame, length / 2);
 }

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
    <modelVersion>4.0.0</modelVersion>
    <groupId>com.pylon</groupId>
    <artifactId>spokestack</artifactId>
-   <version>0.2.1-SNAPSHOT</version>
+   <version>0.2.1</version>
    <packaging>aar</packaging>
    <name>Pylon SpokeStack Library for Android</name>
    <description>Core library of the SpokeStack framework for android</description>
@@ -25,7 +25,7 @@
       <connection>scm:git:git://github.com/pylon/spokestack-android.git</connection>
       <developerConnection>scm:git:git@github.com:pylon/spokestack-android.git</developerConnection>
       <url>https://github.com/pylon/spokestack-android</url>
-      <tag>HEAD</tag>
+      <tag>spokestack-0.2.1</tag>
    </scm>
 
    <prerequisites>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
    <modelVersion>4.0.0</modelVersion>
    <groupId>com.pylon</groupId>
    <artifactId>spokestack</artifactId>
-   <version>0.2.1</version>
+   <version>0.2.2-SNAPSHOT</version>
    <packaging>aar</packaging>
    <name>Pylon SpokeStack Library for Android</name>
    <description>Core library of the SpokeStack framework for android</description>
@@ -25,7 +25,7 @@
       <connection>scm:git:git://github.com/pylon/spokestack-android.git</connection>
       <developerConnection>scm:git:git@github.com:pylon/spokestack-android.git</developerConnection>
       <url>https://github.com/pylon/spokestack-android</url>
-      <tag>spokestack-0.2.1</tag>
+      <tag>HEAD</tag>
    </scm>
 
    <prerequisites>

--- a/src/main/java/com/pylon/spokestack/OnSpeechEventListener.java
+++ b/src/main/java/com/pylon/spokestack/OnSpeechEventListener.java
@@ -11,6 +11,8 @@ public interface OnSpeechEventListener {
      * receives a speech event.
      * @param event   the name of the event that was raised
      * @param context the current speech context
+     * @throws Exception on error
      */
-    void onEvent(SpeechContext.Event event, SpeechContext context);
+    void onEvent(SpeechContext.Event event, SpeechContext context)
+        throws Exception;
 }

--- a/src/main/java/com/pylon/spokestack/SpeechPipeline.java
+++ b/src/main/java/com/pylon/spokestack/SpeechPipeline.java
@@ -75,7 +75,7 @@ public final class SpeechPipeline implements AutoCloseable {
         this.inputClass = builder.inputClass;
         this.stageClasses = builder.stageClasses;
         this.config = builder.config;
-        this.context = new SpeechContext();
+        this.context = new SpeechContext(this.config);
         this.stages = new ArrayList<>();
 
         for (OnSpeechEventListener l: builder.listeners)
@@ -197,8 +197,10 @@ public final class SpeechPipeline implements AutoCloseable {
             this.input.read(frame);
 
             // dispatch the frame to the stages
-            for (SpeechProcessor stage: this.stages)
+            for (SpeechProcessor stage: this.stages) {
+                frame.rewind();
                 stage.process(this.context, frame);
+            }
         } catch (Exception e) {
             raiseError(e);
         }

--- a/src/main/java/com/pylon/spokestack/SpeechSampler.java
+++ b/src/main/java/com/pylon/spokestack/SpeechSampler.java
@@ -1,0 +1,116 @@
+package com.pylon.spokestack;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * speech sampling logger.
+ *
+ * <p>
+ * This is the spokestack pipeline component for logging speech samples. The
+ * samples are written in the wav format to the configured output directory
+ * with rotating file names. The sampler is useful for debugging pipeline
+ * configuration, microphone levels, etc. The sampler only logs audio samples
+ * that correspond to speech (where context.isSpeech() is true).
+ * </p>
+ *
+ * <p>
+ * This pipeline component supports the following configuration properties:
+ * </p>
+ * <ul>
+ *   <li>
+ *      <b>sample-log-path</b> (string): path to the directory to write logs
+ *   </li>
+ *   <li>
+ *      <b>sample-log-max-files</b> (int): maximum number of rotated files
+ *      to create (default: 10)
+ *   </li>
+ * </ul>
+ *
+ */
+public final class SpeechSampler implements SpeechProcessor {
+    /** default maximum number of rotated sample files. */
+    public static final int DEFAULT_SAMPLE_MAX = 10;
+
+    private final String logPath;
+    private final int sampleMax;
+    private int sampleId;
+    private FileOutputStream stream;
+    private final ByteBuffer header;
+
+    /**
+     * constructs a new sampler instance.
+     * @param config the pipeline configuration instance
+     * @throws Exception on error
+     */
+    public SpeechSampler(SpeechConfig config) throws Exception {
+        this.logPath = config.getString("sample-log-path");
+        this.sampleMax = config.getInteger(
+            "sample-log-max-files",
+            DEFAULT_SAMPLE_MAX);
+
+        // create the log path if it doesn't exist
+        new File(logPath).mkdirs();
+
+        // create the wav file header
+        int sampleRate = config.getInteger("sample-rate");
+        this.header = ByteBuffer
+            .allocate(44)
+            .order(ByteOrder.LITTLE_ENDIAN);
+        // riff/wave header
+        this.header.put("RIFF".getBytes("ASCII"));
+        this.header.putInt(Integer.MAX_VALUE);
+        this.header.put("WAVE".getBytes("ASCII"));
+        // format chunk
+        this.header.put("fmt ".getBytes("ASCII"));
+        this.header.putInt(16);                     // size of format chunk
+        this.header.putShort((short) 1);            // pcm
+        this.header.putShort((short) 1);            // channels
+        this.header.putInt(sampleRate);             // sample rate
+        this.header.putInt(sampleRate * 2);         // byte rate
+        this.header.putShort((short) 2);            // block align
+        this.header.putShort((short) 16);           // bits per sample
+        // data chunk
+        this.header.put("data".getBytes("ASCII"));
+        this.header.putInt(Integer.MAX_VALUE);      // size of data chunk
+    }
+
+    /**
+     * destroys the resources attached to the copmonent.
+     * @throws Exception on error
+     */
+    public void close() throws Exception {
+        if (this.stream != null)
+            this.stream.close();
+    }
+
+    /**
+     * processes a frame of audio.
+     * @param context the current speech context
+     * @param frame   the audio frame to detect
+     * @throws Exception on error
+     */
+    public void process(SpeechContext context, ByteBuffer frame)
+            throws Exception {
+        if (context.isSpeech() && this.stream == null) {
+            // speech rising edge, create and attach the log file
+            File file = new File(
+                this.logPath,
+                String.format("%05d.wav", this.sampleId++ % this.sampleMax));
+            this.stream = new FileOutputStream(file);
+            this.stream.write(this.header.array());
+        } else if (!context.isSpeech() && this.stream != null) {
+            // speech falling edge, flush changes and close
+            this.stream.close();
+            this.stream = null;
+        }
+        // write the current audio frame to the wav file
+        if (this.stream != null) {
+            byte[] data = new byte[frame.remaining()];
+            frame.get(data);
+            this.stream.write(data);
+        }
+    }
+}

--- a/src/main/java/com/pylon/spokestack/libfvad/package-info.java
+++ b/src/main/java/com/pylon/spokestack/libfvad/package-info.java
@@ -1,5 +1,0 @@
-/**
- * This package wraps the libfvad (https://github.com/dpirch/libfvad) native
- * modules for voice activity detection (VAD).
- */
-package com.pylon.spokestack.libfvad;

--- a/src/main/java/com/pylon/spokestack/webrtc/AutomaticGainControl.java
+++ b/src/main/java/com/pylon/spokestack/webrtc/AutomaticGainControl.java
@@ -1,0 +1,159 @@
+package com.pylon.spokestack.webrtc;
+
+import java.nio.ByteBuffer;
+
+import com.pylon.spokestack.SpeechConfig;
+import com.pylon.spokestack.SpeechProcessor;
+import com.pylon.spokestack.SpeechContext;
+import com.pylon.spokestack.SpeechContext.TraceLevel;
+
+/**
+ * Automatic Gain Control (AGC) pipeline component
+ *
+ * <p>
+ * The AGC amplifies/attenuates audio samples to maintain a configured
+ * peak amplitude, in dBFS (decibels full-scale). The gain controller is
+ * implemented by the native webrtc framework and modifies the audio buffer
+ * in place.
+ * </p>
+ *
+ * <p>
+ * This pipeline component supports the following configuration properties:
+ * </p>
+ * <ul>
+ *   <li>
+ *      <b>sample-rate</b> (int): audio sample rate, in Hz
+ *      (supports 8000/16000/32000Hz)
+ *   </li>
+ *   <li>
+ *      <b>frame-width</b> (int): audio frame width, in ms
+ *      (supports 10/20ms)
+ *   </li>
+ *   <li>
+ *     <b>agc-target-level-dbfs</b> (int): target peak audio level, in -dBFS
+ *     for example, to maintain a peak of -9dBFS, configure a value of 9
+ *   </li>
+ *   <li>
+ *     <b>agc-compression-gain-db</b> (int): dynamic range compression rate,
+ *     in dB
+ *   </li>
+ * </ul>
+ *
+ */
+public class AutomaticGainControl implements SpeechProcessor {
+    /** default target peak amplitude, in dBFS. */
+    public static final int DEFAULT_TARGET_LEVEL_DBFS = 3;
+    /** default compression gain, in dB. */
+    public static final int DEFAULT_COMPRESSION_GAIN_DB = 9;
+
+    // native agc structure handle
+    private final long agcHandle;
+
+    // controller output levels and counters, for tracing
+    private final int maxCounter;
+    private double level;
+    private int counter;
+
+    /**
+     * constructs a new AGC instance.
+     * @param config the pipeline configuration instance
+     */
+    public AutomaticGainControl(SpeechConfig config) {
+        // decode and validate the sample rate
+        int rate = config.getInteger("sample-rate");
+        switch (rate) {
+            case 8000: break;
+            case 16000: break;
+            case 32000: break;
+            default: throw new IllegalArgumentException("sample-rate");
+        }
+
+        // decode and validate the frame width
+        int frameWidth = config.getInteger("frame-width");
+        switch (frameWidth) {
+            case 10: break;
+            case 20: break;
+            default: throw new IllegalArgumentException("frame-width");
+        }
+
+        // perf trace every second
+        this.maxCounter = 1000 / frameWidth;
+
+        // decode the agc parameters
+        int targetLeveldBFS = config.getInteger(
+            "agc-target-level-dbfs",
+            DEFAULT_TARGET_LEVEL_DBFS);
+
+        int compressionGaindB = config.getInteger(
+            "agc-compression-gain-db",
+            DEFAULT_COMPRESSION_GAIN_DB);
+
+        // create the native agc context
+        this.agcHandle = create(rate, targetLeveldBFS, compressionGaindB, true);
+        if (this.agcHandle == 0)
+            throw new OutOfMemoryError();
+    }
+
+    /**
+     * destroys the unmanaged AGC instance.
+     */
+    public void close() {
+        destroy(this.agcHandle);
+    }
+
+    /**
+     * processes a frame of audio.
+     * @param context the current speech context
+     * @param frame   the audio frame to detect
+     */
+    public void process(SpeechContext context, ByteBuffer frame) {
+        // run the native gain controller,
+        // which will update the frame buffer
+        int result = process(this.agcHandle, frame, frame.capacity());
+        if (result < 0)
+            throw new IllegalStateException();
+
+        // trace the amplification levels
+        if (context.canTrace(TraceLevel.PERF)) {
+            // measure the updated sample RMS dBFS
+            // maintain a running mean of the levels
+            double frameLevel = rms(frame);
+            this.counter++;
+            this.level += (frameLevel - this.level) / this.counter;
+
+            // trace them once per tracing interval
+            this.counter %= this.maxCounter;
+            if (this.counter == 0)
+                context.tracePerf("agc: %.4f", this.level);
+        }
+    }
+
+    private double rms(ByteBuffer signal) {
+        double sum = 0;
+        int count = 0;
+
+        signal.rewind();
+        while (signal.hasRemaining()) {
+            double sample = (double) signal.getShort() / Short.MAX_VALUE;
+            sum += sample * sample;
+            count++;
+        }
+
+        return 20 * Math.log10(Math.max(Math.sqrt(sum / count), 1e-5));
+    }
+
+    //-----------------------------------------------------------------------
+    // native interface
+    //-----------------------------------------------------------------------
+    static {
+        System.loadLibrary("spokestack");
+    }
+
+    native long create(
+        int rate,
+        int targetLeveldBFS,
+        int compressionGaindB,
+        boolean limiterEnable);
+    native void destroy(long agc);
+    native int process(long agc, ByteBuffer buffer, int length);
+}

--- a/src/main/java/com/pylon/spokestack/webrtc/VoiceActivityTrigger.java
+++ b/src/main/java/com/pylon/spokestack/webrtc/VoiceActivityTrigger.java
@@ -1,0 +1,53 @@
+package com.pylon.spokestack.webrtc;
+
+import java.nio.ByteBuffer;
+
+import com.pylon.spokestack.SpeechConfig;
+import com.pylon.spokestack.SpeechProcessor;
+import com.pylon.spokestack.SpeechContext;
+
+/**
+ * Voice Activity Detector (VAD) trigger pipeline component
+ *
+ * <p>
+ * VoiceActivityTrigger is a speech pipeline component that implements Voice
+ * Activity Detection (VAD) using the VoiceActivityDetector class. The
+ * trigger activates the speech context whenever speech is detected.
+ * </p>
+ *
+ */
+public class VoiceActivityTrigger implements SpeechProcessor {
+    private boolean isSpeech = false;
+
+    /**
+     * constructs a new trigger instance.
+     * @param config the pipeline configuration instance
+     */
+    public VoiceActivityTrigger(SpeechConfig config) {
+    }
+
+    /**
+     * pipeline cleanup.
+     */
+    public void close() {
+    }
+
+    /**
+     * processes a frame of audio.
+     * @param context the current speech context
+     * @param frame   the audio frame to detect
+     */
+    public void process(SpeechContext context, ByteBuffer frame) {
+        // activate the context on speech edge
+        if (context.isSpeech() != this.isSpeech) {
+            if (context.isSpeech()) {
+                context.setActive(true);
+                context.dispatch(SpeechContext.Event.ACTIVATE);
+            } else {
+                context.setActive(false);
+                context.dispatch(SpeechContext.Event.DEACTIVATE);
+            }
+            this.isSpeech = context.isSpeech();
+        }
+    }
+}

--- a/src/main/java/com/pylon/spokestack/webrtc/package-info.java
+++ b/src/main/java/com/pylon/spokestack/webrtc/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * This package wraps the webrtc native modules for Voice Activity Detection
+ * (VAD) and Automatic Gain Control (AGC).
+ */
+package com.pylon.spokestack.webrtc;

--- a/src/test/java/com/pylon/spokestack/SpeechSamplerTest.java
+++ b/src/test/java/com/pylon/spokestack/SpeechSamplerTest.java
@@ -1,0 +1,77 @@
+import java.io.File;
+import java.util.*;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.rules.TemporaryFolder;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.pylon.spokestack.SpeechConfig;
+import com.pylon.spokestack.SpeechContext;
+import com.pylon.spokestack.SpeechSampler;
+
+public class SpeechSamplerTest {
+    @Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
+
+    @Test
+    public void testConstruction() throws Exception {
+        // default config
+        final SpeechConfig config = new SpeechConfig()
+            .put("sample-rate", 8000)
+            .put("sample-log-path", testFolder.getRoot().toString());
+        new SpeechSampler(config);
+
+        // valid config
+        config.put("sample-log-max-files", 20);
+        new SpeechSampler(config);
+
+        // close coverage
+        new SpeechSampler(config).close();
+    }
+
+    @Test
+    public void testProcessing() throws Exception {
+        final SpeechConfig config = new SpeechConfig()
+            .put("sample-rate", 8000)
+            .put("frame-width", 10)
+            .put("sample-log-path", testFolder.getRoot())
+            .put("sample-log-max-files", 5);
+        final SpeechContext context = new SpeechContext(config);
+        final SpeechSampler sampler = new SpeechSampler(config);
+
+        // non-speech samples
+        sampler.process(context, sampleBuffer(config));
+        assertEquals(0, testFolder.getRoot().listFiles().length);
+
+        // speech samples
+        for (int i = 0; i < 2 * config.getInteger("sample-log-max-files"); i++) {
+            context.setSpeech(true);
+            sampler.process(context, sampleBuffer(config));
+            sampler.process(context, sampleBuffer(config));
+            context.setSpeech(false);
+            sampler.process(context, sampleBuffer(config));
+            sampler.process(context, sampleBuffer(config));
+        }
+        assertEquals(
+            config.getInteger("sample-log-max-files"),
+            testFolder.getRoot().listFiles().length);
+
+        // close with speech
+        context.setSpeech(true);
+        sampler.process(context, sampleBuffer(config));
+        sampler.close();
+    }
+
+    private ByteBuffer sampleBuffer(SpeechConfig config) {
+        int samples = config.getInteger("sample-rate")
+            / 1000
+            * config.getInteger("frame-width");
+        return ByteBuffer
+            .allocateDirect(samples * 2)
+            .order(ByteOrder.nativeOrder());
+    }
+}

--- a/src/test/java/com/pylon/spokestack/google/GoogleSpeechRecognizerTest.java
+++ b/src/test/java/com/pylon/spokestack/google/GoogleSpeechRecognizerTest.java
@@ -29,10 +29,11 @@ public class GoogleSpeechRecognizerTest implements OnSpeechEventListener {
     @Test
     @SuppressWarnings("unchecked")
     public void testRecognize() throws Exception {
-        SpeechContext context = createContext();
+        SpeechConfig config = createConfig();
+        SpeechContext context = createContext(config);
         MockSpeechClient client = spy(MockSpeechClient.class);
         GoogleSpeechRecognizer recognizer =
-            new GoogleSpeechRecognizer(createConfig(), client);
+            new GoogleSpeechRecognizer(config, client);
 
         // inactive
         recognizer.process(context, context.getBuffer().getLast());
@@ -80,10 +81,11 @@ public class GoogleSpeechRecognizerTest implements OnSpeechEventListener {
     @Test
     @SuppressWarnings("unchecked")
     public void testError() throws Exception {
-        SpeechContext context = createContext();
+        SpeechConfig config = createConfig();
+        SpeechContext context = createContext(config);
         MockSpeechClient client = spy(MockSpeechClient.class);
         GoogleSpeechRecognizer recognizer =
-            new GoogleSpeechRecognizer(createConfig(), client);
+            new GoogleSpeechRecognizer(config, client);
 
         // trigger recognition
         context.setActive(true);
@@ -107,8 +109,8 @@ public class GoogleSpeechRecognizerTest implements OnSpeechEventListener {
         return config;
     }
 
-    private SpeechContext createContext() {
-        SpeechContext context = new SpeechContext();
+    private SpeechContext createContext(SpeechConfig config) {
+        SpeechContext context = new SpeechContext(config);
         context.addOnSpeechEventListener(this);
 
         context.attachBuffer(new LinkedList<ByteBuffer>());

--- a/src/test/java/com/pylon/spokestack/microsoft/BingSpeechRecognizerTest.java
+++ b/src/test/java/com/pylon/spokestack/microsoft/BingSpeechRecognizerTest.java
@@ -22,9 +22,10 @@ public class BingSpeechRecognizerTest implements OnSpeechEventListener {
         BingSpeechClient client = mock(BingSpeechClient.class);
         doReturn(client).when(builder).build();
 
-        SpeechContext context = createContext();
+        SpeechConfig config = createConfig();
+        SpeechContext context = createContext(config);
         BingSpeechRecognizer recognizer =
-            new BingSpeechRecognizer(createConfig(), builder);
+            new BingSpeechRecognizer(config, builder);
 
         // capture the listener
         ArgumentCaptor<BingSpeechClient.Listener> captor =
@@ -82,9 +83,10 @@ public class BingSpeechRecognizerTest implements OnSpeechEventListener {
         BingSpeechClient client = mock(BingSpeechClient.class);
         doReturn(client).when(builder).build();
 
-        SpeechContext context = createContext();
+        SpeechConfig config = createConfig();
+        SpeechContext context = createContext(config);
         BingSpeechRecognizer recognizer =
-            new BingSpeechRecognizer(createConfig(), builder);
+            new BingSpeechRecognizer(config, builder);
 
         // capture the listener
         ArgumentCaptor<BingSpeechClient.Listener> captor =
@@ -116,8 +118,8 @@ public class BingSpeechRecognizerTest implements OnSpeechEventListener {
         return config;
     }
 
-    private SpeechContext createContext() {
-        SpeechContext context = new SpeechContext();
+    private SpeechContext createContext(SpeechConfig config) {
+        SpeechContext context = new SpeechContext(config);
         context.addOnSpeechEventListener(this);
 
         context.attachBuffer(new LinkedList<ByteBuffer>());

--- a/src/test/java/com/pylon/spokestack/webrtc/AutomaticGainControlTest.java
+++ b/src/test/java/com/pylon/spokestack/webrtc/AutomaticGainControlTest.java
@@ -1,0 +1,159 @@
+import java.util.*;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.pylon.spokestack.SpeechConfig;
+import com.pylon.spokestack.SpeechContext;
+import com.pylon.spokestack.webrtc.AutomaticGainControl;
+
+public class AutomaticGainControlTest {
+
+    @Test
+    public void testConstruction() {
+        // default config
+        final SpeechConfig config = new SpeechConfig();
+        config.put("sample-rate", 8000);
+        config.put("frame-width", 10);
+        new AutomaticGainControl(config);
+
+        // invalid sample rate
+        config.put("sample-rate", 48000);
+        config.put("frame-width", 20);
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            public void execute() { new AutomaticGainControl(config); }
+        });
+
+        // invalid frame width
+        config.put("sample-rate", 8000);
+        config.put("frame-width", 25);
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            public void execute() { new AutomaticGainControl(config); }
+        });
+
+        // invalid target level
+        config.put("agc-target-level-dbfs", "invalid");
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            public void execute() { new AutomaticGainControl(config); }
+        });
+
+        // invalid compression gain
+        config.put("agc-compression-gain-db", "invalid");
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            public void execute() { new AutomaticGainControl(config); }
+        });
+
+        // valid config
+        config.put("sample-rate", 16000);
+        config.put("frame-width", 20);
+        config.put("agc-target-level-dbfs", 3);
+        config.put("agc-compression-gain-db", 9);
+        new AutomaticGainControl(config);
+
+        // valid rates
+        config.put("sample-rate", 8000);
+        new AutomaticGainControl(config);
+        config.put("sample-rate", 16000);
+        new AutomaticGainControl(config);
+        config.put("sample-rate", 32000);
+        new AutomaticGainControl(config);
+
+        // valid widths
+        config.put("frame-width", 10);
+        new AutomaticGainControl(config);
+        config.put("frame-width", 20);
+        new AutomaticGainControl(config);
+
+        // close coverage
+        new AutomaticGainControl(config).close();
+    }
+
+    @Test
+    public void testProcessing() {
+        final SpeechConfig config = new SpeechConfig()
+            .put("sample-rate", 8000)
+            .put("frame-width", 10)
+            .put("agc-target-level-dbfs", 9)
+            .put("agc-compression-gain-db", 2);
+
+        final SpeechContext context = new SpeechContext(config);
+        AutomaticGainControl agc;
+        ByteBuffer frame;
+        double level;
+
+        // invalid frame
+        assertThrows(IllegalStateException.class, new Executable() {
+            public void execute() {
+                new AutomaticGainControl(config)
+                    .process(context, ByteBuffer.allocateDirect(1));
+            }
+        });
+
+        // valid amplification
+        agc = new AutomaticGainControl(config);
+        frame = sinFrame(config, 0.08);
+        level = rms(frame);
+        agc.process(context, frame);
+        assertTrue(rms(frame) > level);
+
+        // valid attenuation
+        agc = new AutomaticGainControl(config);
+        frame = sinFrame(config, 1.0);
+        level = rms(frame);
+        agc.process(context, frame);
+        assertTrue(rms(frame) < level);
+    }
+
+    @Test
+    public void testTracing() {
+        final SpeechConfig config = new SpeechConfig()
+            .put("sample-rate", 8000)
+            .put("frame-width", 10)
+            .put("trace-level", SpeechContext.TraceLevel.PERF.value());
+        final SpeechContext context = new SpeechContext(config);
+        final AutomaticGainControl agc = new AutomaticGainControl(config);
+        for (int i = 0; i < 100; i++)
+            agc.process(context, sinFrame(config, 0.08));
+        assertTrue(context.getMessage() != null);
+    }
+
+    private ByteBuffer sinFrame(SpeechConfig config, double amplitude) {
+        ByteBuffer buffer = sampleBuffer(config);
+        double rate = config.getInteger("sample-rate");
+        double freq = 2000;
+        for (int i = 0; i < buffer.capacity() / 2; i++) {
+            double sample =
+                amplitude
+                * Math.sin((double)i / (rate / freq) * 2 * Math.PI);
+            buffer.putShort((short)(sample * Short.MAX_VALUE));
+        }
+        buffer.rewind();
+        return buffer;
+    }
+
+    private ByteBuffer sampleBuffer(SpeechConfig config) {
+        int samples = config.getInteger("sample-rate")
+            / 1000
+            * config.getInteger("frame-width");
+        return ByteBuffer
+            .allocateDirect(samples * 2)
+            .order(ByteOrder.nativeOrder());
+    }
+
+    private double rms(ByteBuffer signal) {
+        double sum = 0;
+        int count = 0;
+
+        signal.rewind();
+        while (signal.hasRemaining()) {
+            double sample = (double) signal.getShort() / Short.MAX_VALUE;
+            sum += sample * sample;
+            count++;
+        }
+
+        return 20 * Math.log10(Math.max(Math.sqrt(sum / count), 1e-5));
+    }
+}

--- a/src/test/java/com/pylon/spokestack/webrtc/VoiceActivityTriggerTest.java
+++ b/src/test/java/com/pylon/spokestack/webrtc/VoiceActivityTriggerTest.java
@@ -1,0 +1,78 @@
+import java.util.*;
+import java.nio.ByteBuffer;
+
+import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.pylon.spokestack.OnSpeechEventListener;
+import com.pylon.spokestack.SpeechConfig;
+import com.pylon.spokestack.SpeechContext;
+import com.pylon.spokestack.webrtc.VoiceActivityTrigger;
+
+public class VoiceActivityTriggerTest implements OnSpeechEventListener {
+    private SpeechContext.Event event;
+
+    @Test
+    public void testConstruction() {
+        // default config
+        final SpeechConfig config = new SpeechConfig();
+        config.put("sample-rate", 8000);
+        config.put("frame-width", 10);
+        new VoiceActivityTrigger(config);
+
+        // close coverage
+        new VoiceActivityTrigger(config).close();
+    }
+
+    @Test
+    public void testProcessing() {
+        final SpeechConfig config = new SpeechConfig();
+        config.put("sample-rate", 8000);
+        config.put("frame-width", 10);
+
+        final SpeechContext context = new SpeechContext(config);
+        final VoiceActivityTrigger vad = new VoiceActivityTrigger(config);
+        context.addOnSpeechEventListener(this);
+
+        // initial silence
+        vad.process(context, sampleBuffer(config));
+        assertEquals(null, this.event);
+        assertFalse(context.isActive());
+
+        // speech transition
+        context.setSpeech(true);
+        vad.process(context, sampleBuffer(config));
+        assertEquals(SpeechContext.Event.ACTIVATE, this.event);
+        assertTrue(context.isActive());
+
+        // continued speech
+        this.event = null;
+        vad.process(context, sampleBuffer(config));
+        assertEquals(null, this.event);
+        assertTrue(context.isActive());
+
+        // silence transition
+        context.setSpeech(false);
+        vad.process(context, sampleBuffer(config));
+        assertEquals(SpeechContext.Event.DEACTIVATE, this.event);
+        assertFalse(context.isActive());
+
+        // continued silence
+        this.event = null;
+        vad.process(context, sampleBuffer(config));
+        assertEquals(null, this.event);
+        assertFalse(context.isActive());
+    }
+
+    private ByteBuffer sampleBuffer(SpeechConfig config) {
+        int samples = config.getInteger("sample-rate")
+            / 1000
+            * config.getInteger("frame-width");
+        return ByteBuffer.allocateDirect(samples * 2);
+    }
+
+    public void onEvent(SpeechContext.Event event, SpeechContext context) {
+        this.event = event;
+    }
+}


### PR DESCRIPTION
Tracing and logging have been added to the spokestack pipeline. Tracing is off by default and can be enabled through the `trace-level` parameter, which defines the minimum tracing level in order of (DEBUG, PERF, and INFO). Logging has been implemented in the SpeechSampler, which will save wav files for speech audio on the device's SD card.

Spokestack has also been modified to use a different repo for the webrtc audio components, which also includes support for automatic gain control, noise suppression, echo suppression, etc. For now, I have integrated AGC, which gives us much better wakeword detector performance, at least on my phone, which does not have built-in AGC (I don't know if any phones do).

The VAD has been decoupled from the wakeword detector and split into detector and trigger components. The detector detects voiced audio and sets the "speech" indicator on the SpeechContext. The VAD trigger uses this indicator to activate the speech context. Wakeword detection pipelines should include the VAD component in the stack prior to the wakeword trigger. The example pipeline in the readme has been updated.

The pre-emphasis filter has been implemented in the wakeword detector, as this also appears to perform better than non-emphasized audio, at least for the wakewords tested. Pre-emphasis is off by default, but it can be enabled by setting `pre-emphasis` to non-zero.

Because we now have support for AGC, RMS normalization has been turned off by default in the wakeword trigger. However, it can be enabled by setting `rms-alpha` to a non-zero value.
