### PR TITLE
Support for timedOut event upon ASR timeout without detecting speech

### DIFF
--- a/src/main/java/com/pylon/spokestack/SpeechContext.java
+++ b/src/main/java/com/pylon/spokestack/SpeechContext.java
@@ -26,7 +26,9 @@ public final class SpeechContext {
         /** a speech error occurred. */
         ERROR("error"),
         /** a trace event occurred. */
-        TRACE("trace");
+        TRACE("trace"),
+        /** speech recognition timed out. */
+        TIMEDOUT("timedout");
 
         private final String event;
 

--- a/src/main/java/com/pylon/spokestack/google/GoogleSpeechRecognizer.java
+++ b/src/main/java/com/pylon/spokestack/google/GoogleSpeechRecognizer.java
@@ -108,8 +108,6 @@ public final class GoogleSpeechRecognizer implements SpeechProcessor {
      * @throws Exception on error
      */
     public void close() throws Exception {
-        if (this.request != null)
-            this.request.onCompleted();
         this.client.close();
     }
 

--- a/src/main/java/com/pylon/spokestack/wakeword/WakewordTrigger.java
+++ b/src/main/java/com/pylon/spokestack/wakeword/WakewordTrigger.java
@@ -374,9 +374,14 @@ public final class WakewordTrigger implements SpeechProcessor {
         } else {
             // continue this wakeword (or external) activation
             // until a vad deactivation or timeout
-            if (++this.activeLength > this.minActive)
-                if (vadFall || this.activeLength > this.maxActive)
+            if (++this.activeLength > this.minActive) {
+                if (vadFall) {
                     deactivate(context);
+                } else if (this.activeLength > this.maxActive) {
+                    timedOut(context);
+                    deactivate(context);
+                }
+            }
         }
 
         // always clear detector state on a vad deactivation
@@ -542,6 +547,12 @@ public final class WakewordTrigger implements SpeechProcessor {
             context.setActive(false);
             context.dispatch(SpeechContext.Event.DEACTIVATE);
             this.activeLength = 0;
+        }
+    }
+
+    private void timedOut(SpeechContext context) {
+        if (context.isActive()) {
+            context.dispatch(SpeechContext.Event.TIMEDOUT);
         }
     }
 


### PR DESCRIPTION
After discussing with @timmywil, there is a need for a new event, `timedOut`, that indicates that ASR, once activated, has not heard any speech and has timed out (by the `wakeActiveMax` time) before the pipeline transitions to the deactivated state. He was previously relying on an undocumented behavior where the `close` function would raise `onRecognize` by side effect with an empty transcript. This behavior was not present in spokestack-ios, and so react-native-spokestack broke cross-platform compatibility. This pair of PRs (https://github.com/pylon/spokestack-ios/pull/26) will allow both platforms to send the same explicit event upon `wakeActiveMax` length of silence.