### PR TITLE
add support for explicit timeout events in the google speech api

### DIFF
--- a/src/main/java/com/pylon/spokestack/SpeechContext.java
+++ b/src/main/java/com/pylon/spokestack/SpeechContext.java
@@ -23,6 +23,8 @@ public final class SpeechContext {
         DEACTIVATE("deactivate"),
         /** speech was recognized. */
         RECOGNIZE("recognize"),
+        /** the activation timeout expired. */
+        TIMEOUT("timeout"),
         /** a speech error occurred. */
         ERROR("error"),
         /** a trace event occurred. */

--- a/src/main/java/com/pylon/spokestack/google/GoogleSpeechRecognizer.java
+++ b/src/main/java/com/pylon/spokestack/google/GoogleSpeechRecognizer.java
@@ -204,7 +204,10 @@ public final class GoogleSpeechRecognizer implements SpeechProcessor {
         public void onCompleted() {
             this.context.setTranscript(this.transcript);
             this.context.setConfidence(this.confidence);
-            this.context.dispatch(SpeechContext.Event.RECOGNIZE);
+            if (this.transcript != "")
+                this.context.dispatch(SpeechContext.Event.RECOGNIZE);
+            else
+                this.context.dispatch(SpeechContext.Event.TIMEOUT);
         }
     }
 }

--- a/src/test/java/com/pylon/spokestack/SpeechContextTest.java
+++ b/src/test/java/com/pylon/spokestack/SpeechContextTest.java
@@ -199,6 +199,7 @@ public class SpeechContextTest implements OnSpeechEventListener {
         assertEquals("activate", Event.ACTIVATE.toString());
         assertEquals("deactivate", Event.DEACTIVATE.toString());
         assertEquals("recognize", Event.RECOGNIZE.toString());
+        assertEquals("timeout", Event.TIMEOUT.toString());
         assertEquals("error", Event.ERROR.toString());
         assertEquals("trace", Event.TRACE.toString());
     }


### PR DESCRIPTION
This converts the recognize with empty transcript event into an explicit timeout event, for compatibility with the ios wakeword detector/speech recognizer.