### PR TITLE
add support for efficient autoregressive wakeword detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,8 @@ SpeechPipeline pipeline = new SpeechPipeline.Builder()
     .addStageClass("com.pylon.spokestack.google.GoogleSpeechRecognizer")
     .setProperty("vad-fall-delay", 200)
     .setProperty("pre-emphasis", 0.97)
-    .setProperty("wake-words", "up,dog")
-    .setProperty("wake-phrases", "up dog")
     .setProperty("wake-filter-path", "<tensorflow-lite-filter-path>")
+    .setProperty("wake-encode-path", "<tensorflow-lite-encode-path>")
     .setProperty("wake-detect-path", "<tensorflow-lite-detect-path>")
     .setProperty("wake-smooth-length", 50)
     .setProperty("google-credentials", "<google-credentials>")
@@ -75,12 +74,13 @@ SpeechPipeline pipeline = new SpeechPipeline.Builder()
     .build();
 ```
 
-This example creates a wakeword-triggered pipeline that uses the phrase
-"up dog" to activate the pipeline for the google speech recognizer. The
-wakeword trigger uses two pretrained [Tensorflow-Lite](https://www.tensorflow.org/lite/)
-models: a *filter* model for spectrum preprocessing and a *detect* model
-for keyword classification. For more information on the wakeword detector
-and its configuration parameters, click [here](https://github.com/pylon/spokestack-android/wiki/wakeword).
+This example creates a wakeword-triggered pipeline with the google speech
+recognizer. The wakeword trigger uses three trained
+[Tensorflow-Lite](https://www.tensorflow.org/lite/) models: a *filter* model
+for spectrum preprocessing, an autoregressive encoder *encode* model, and a
+*detect* decoder model for keyword classification. For more information on
+the wakeword detector and its configuration parameters, click
+[here](https://github.com/pylon/spokestack-android/wiki/wakeword).
 
 ## Development
 Maven is used for building/deployment, and the package is hosted at Maven

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
       <dependency>
          <groupId>org.tensorflow</groupId>
          <artifactId>tensorflow-lite</artifactId>
-         <version>1.10.0</version>
+         <version>1.12.0</version>
          <type>aar</type>
          <scope>provided</scope>
       </dependency>

--- a/src/main/java/com/pylon/spokestack/wakeword/WakewordTrigger.java
+++ b/src/main/java/com/pylon/spokestack/wakeword/WakewordTrigger.java
@@ -1,8 +1,6 @@
 package com.pylon.spokestack.wakeword;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
-import java.util.List;
 
 import org.jtransforms.fft.FloatFFT_1D;
 
@@ -17,10 +15,9 @@ import com.pylon.spokestack.tensorflow.TensorflowModel;
  * <p>
  * WakewordTrigger is a speech pipeline component that provides wakeword
  * detection for activating downstream components. It uses a Tensorflow-Lite
- * classifier to detect keywords (i.e. [null], up, dog) and aggregates them
- * into phrases (up dog). Once a wakeword phrase is detected, the pipeline
- * is activated. The pipeline remains active until the user stops talking
- * or the activation timeout is reached.
+ * binary classifier to detect keyword phrases. Once a wakeword phrase is
+ * detected, the pipeline is activated. The pipeline remains active until the
+ * user stops talking or the activation timeout is reached.
  * </p>
  *
  * <p>
@@ -32,19 +29,26 @@ import com.pylon.spokestack.tensorflow.TensorflowModel;
  * </p>
  *
  * <p>
- * The mel spectrogram represents the features to be passed to the keyword
- * classifier, which is implemented in a "detect" Tensorflow model. This
- * classifier outputs posterior probabilities for each keyword (and a null
- * output 0, which represents non-keyword speech).
+ * The mel spectrogram represents the features to be passed to the
+ * autoregressive encoder (usually an rnn or crnn), which is implemented in
+ * an "encode" Tensorflow model. This encoder outputs an encoded vector and a
+ * state vector. The encoded vectors are batched together into a sliding
+ * window for classification, and the state vector is used to perform the
+ * running autoregressive transduction over the mel frames.
  * </p>
  *
  * <p>
- * The detector's outputs are considered noisy, so they are maintained in a
- * sliding window and passed through a moving mean filter. The smoothed
- * posteriors are then maintained in another sliding window for phrasing. The
- * phraser attempts to match one of the configured keyword sequences using
- * the maximum posterior for each word. If a sequence match is found, the
- * speech pipeline is activated.
+ * The "detect" Tensorflow model takes the encoded sliding window and outputs
+ * a single posterior value in the range [0, 1]. Values closer to 1 indicate
+ * a detected keyword phrase, values closer to 0 indicate non-keyword speech.
+ * This classifier is commonly implemented as an attention mechanism over the
+ * encoder window.
+ * </p>
+ *
+ * <p>
+ * The detector's outputs are then compared against a configured threshold,
+ * in order to determine whether to activate the pipeline. If the posterior
+ * is greater than the thresold, the activation occurs.
  * </p>
  *
  * <p>
@@ -69,36 +73,22 @@ import com.pylon.spokestack.tensorflow.TensorflowModel;
  * </p>
  * <ul>
  *   <li>
- *      <b>wake-words</b> (string, required): a comma-separated list of the
- *      keywords, in the order they appear in the classifier outputs, not
- *      including the null (non-keyword) class
- *      (ex: "up,dog")
- *   </li>
- *   <li>
- *      <b>wake-phrases</b> (string): a comma-separated list of
- *      space-separated keyword phrases to detect, which defaults to no
- *      phrases (just individual keywords)
- *      (ex: "up dog,dog dog")
- *   </li>
- *   <li>
  *      <b>wake-filter-path</b> (string, required): file system path to the
  *      "filter" Tensorflow-Lite model, which is used to calculate a mel
  *      spectrogram frame from the linear STFT; its inputs should be shaped
  *      [fft-width], and its outputs [mel-width]
  *   </li>
  *   <li>
+ *      <b>wake-encode-path</b> (string, required): file system path to the
+ *      "encode" Tensorflow-Lite model, which is used to perform each
+ *      autoregressive step over the mel frames; its inputs should be shaped
+ *      [mel-length, mel-width], and its outputs [encode-width], with an
+ *      additional state input/output shaped [state-width]
+ *   </li>
+ *   <li>
  *      <b>wake-detect-path</b> (string, required): file system path to the
  *      "detect" Tensorflow-Lite model; its inputs shoudld be shaped
- *      [mel-length, mel-width], and its outputs [word-count + 1]
- *   </li>
- *   <li>
- *      <b>wake-smooth-length</b> (integer): the length of the posterior
- *      smoothing window to use with the classifier's outputs, in milliseconds
- *   </li>
- *   <li>
- *      <b>wake-phrase-length</b> (integer): the length of the phraser's
- *      sliding window, in milliseconds - this value should be long enough to
- *      fit the longest supported phrase
+ *      [encode-length, encode-width], and its outputs [1]
  *   </li>
  *   <li>
  *      <b>wake-active-min</b> (integer): the minimum length of an activation,
@@ -138,11 +128,29 @@ import com.pylon.spokestack.tensorflow.TensorflowModel;
  *   </li>
  *   <li>
  *      <b>mel-frame-length</b> (integer): the length of the mel spectrogram
- *      used as an input to the classifier, in milliseconds
+ *      used as an input to the encoder, in milliseconds
  *   </li>
  *   <li>
  *      <b>mel-frame-width</b> (integer): the size of each mel spectrogram
  *      frame, in number of filterbank components
+ *   </li>
+ *   <li>
+ *      <b>wake-encode-length</b> (integer): the length of the sliding
+ *      window of encoder output used as an input to the classifier, in
+ *      milliseconds
+ *   </li>
+ *   <li>
+ *      <b>wake-encode-width</b> (integer): the size of the encoder output,
+ *      in vector units
+ *   </li>
+ *   <li>
+ *      <b>wake-state-width</b> (integer): the size of the encoder state,
+ *      in vector units (defaults to wake-encode-width)
+ *   </li>
+ *   <li>
+ *      <b>wake-threshold</b> (double): the threshold of the classifier's
+ *      posterior output, above which the trigger activates the pipeline,
+ *      in the range [0, 1]
  *   </li>
  * </ul>
  */
@@ -163,13 +171,15 @@ public final class WakewordTrigger implements SpeechProcessor {
     /** default fft-hop-length configuration value. */
     public static final int DEFAULT_FFT_HOP_LENGTH = 10;
     /** default mel-frame-length configuration value. */
-    public static final int DEFAULT_MEL_FRAME_LENGTH = 400;
+    public static final int DEFAULT_MEL_FRAME_LENGTH = 10;
     /** default mel-frame-width configuration value. */
     public static final int DEFAULT_MEL_FRAME_WIDTH = 40;
-    /** default wake-smooth-length configuration value. */
-    public static final int DEFAULT_WAKE_SMOOTH_LENGTH = 300;
-    /** default wake-frame-length configuration value. */
-    public static final int DEFAULT_WAKE_PHRASE_LENGTH = 500;
+    /** default wake-encode-length configuration value. */
+    public static final int DEFAULT_WAKE_ENCODE_LENGTH = 1000;
+    /** default wake-encode-width configuration value. */
+    public static final int DEFAULT_WAKE_ENCODE_WIDTH = 128;
+    /** default wake-threshold value. */
+    public static final float DEFAULT_WAKE_THRESHOLD = 0.5f;
     /** default wake-active-min configuration value. */
     public static final int DEFAULT_WAKE_ACTIVE_MIN = 500;
     /** default wake-active-max configuration value. */
@@ -177,13 +187,6 @@ public final class WakewordTrigger implements SpeechProcessor {
 
     // voice activity detection
     private boolean isSpeech;
-
-    // keyword/phrase configuration and preallocated buffers
-    private final String[] words;
-    private final int[][] phrases;
-    private final float[] phraseSum;
-    private final int[] phraseArg;
-    private final float[] phraseMax;
 
     // audio signal normalization and pre-emphasis
     private final float rmsTarget;
@@ -199,17 +202,22 @@ public final class WakewordTrigger implements SpeechProcessor {
     private final int hopLength;
     private final int melWidth;
 
+    // encoder configuration
+    private final int encodeWidth;
+
     // sliding window buffers
     private final RingBuffer sampleWindow;
     private final RingBuffer frameWindow;
-    private final RingBuffer smoothWindow;
-    private final RingBuffer phraseWindow;
+    private final RingBuffer encodeWindow;
 
     // tensorflow mel filtering and classifier models
     private final TensorflowModel filterModel;
+    private final TensorflowModel encodeModel;
     private final TensorflowModel detectModel;
 
     // wakeword activation management
+    private final float posteriorThreshold;
+    private float posteriorMax;
     private final int minActive;
     private final int maxActive;
     private int activeLength;
@@ -230,36 +238,6 @@ public final class WakewordTrigger implements SpeechProcessor {
     public WakewordTrigger(
             SpeechConfig config,
             TensorflowModel.Loader loader) {
-        // parse the configured list of keywords
-        // allocate an additional slot for the non-keyword class at 0
-        List<String> wakeWords = Arrays
-            .asList(config.getString("wake-words").split(","));
-        this.words = new String[wakeWords.size() + 1];
-        for (int i = 1; i < this.words.length; i++)
-            this.words[i] = wakeWords.get(i - 1);
-
-        // parse the keyword phrase configuration
-        String[] wakePhrases = config
-            .getString("wake-phrases", String.join(",", wakeWords))
-            .split(",");
-        this.phrases = new int[wakePhrases.length][];
-        for (int i = 0; i < wakePhrases.length; i++) {
-            String[] wakePhrase = wakePhrases[i].split(" ");
-
-            // allocate an additional (null) slot at the end of each phrase,
-            // which forces the phraser to continue detection until the end
-            // of the final keyword in each phrase
-            this.phrases[i] = new int[wakePhrase.length + 1];
-            for (int j = 0; j < wakePhrase.length; j++) {
-                // verify that each keyword in the phrase is a known keyword
-                int k = wakeWords.indexOf(wakePhrase[j]);
-                if (k == -1)
-                    throw new IllegalArgumentException("wake-phrases");
-
-                this.phrases[i][j] = k + 1;
-            }
-        }
-
         // fetch signal normalization config
         this.rmsTarget = (float) config
             .getDouble("rms-target", (double) DEFAULT_RMS_TARGET);
@@ -296,25 +274,24 @@ public final class WakewordTrigger implements SpeechProcessor {
         this.fft = new FloatFFT_1D(windowSize);
         this.fftFrame = new float[windowSize];
 
-        // fetch smoothing/phrasing window lengths
-        int smoothLength = config
-            .getInteger("wake-smooth-length", DEFAULT_WAKE_SMOOTH_LENGTH)
+        // fetch and validate encoder configuration
+        int encodeLength = config
+            .getInteger("wake-encode-length", DEFAULT_WAKE_ENCODE_LENGTH)
             * sampleRate / 1000 / this.hopLength;
-        int phraseLength = config
-            .getInteger("wake-phrase-length", DEFAULT_WAKE_PHRASE_LENGTH)
-            * sampleRate / 1000 / this.hopLength;
+        this.encodeWidth = config
+            .getInteger("wake-encode-width", DEFAULT_WAKE_ENCODE_WIDTH);
+        int stateWidth = config
+            .getInteger("wake-state-width", this.encodeWidth);
 
         // allocate sliding windows
         // fill all buffers (except samples) with zero, in order to
         // minimize detection delay caused by buffering
         this.sampleWindow = new RingBuffer(windowSize);
         this.frameWindow = new RingBuffer(melLength * this.melWidth);
-        this.smoothWindow = new RingBuffer(smoothLength * this.words.length);
-        this.phraseWindow = new RingBuffer(phraseLength * this.words.length);
+        this.encodeWindow = new RingBuffer(encodeLength * this.encodeWidth);
 
         this.frameWindow.fill(0);
-        this.smoothWindow.fill(0);
-        this.phraseWindow.fill(0);
+        this.encodeWindow.fill(0);
 
         // load the tensorflow-lite models
         this.filterModel = loader
@@ -322,21 +299,22 @@ public final class WakewordTrigger implements SpeechProcessor {
             .setInputShape(windowSize / 2 + 1)
             .setOutputShape(this.melWidth)
             .load();
+        this.encodeModel = loader
+            .setPath(config.getString("wake-encode-path"))
+            .setInputShape(melLength * this.melWidth)
+            .setOutputShape(this.encodeWidth)
+            .setStateShape(stateWidth)
+            .load();
         this.detectModel = loader
             .setPath(config.getString("wake-detect-path"))
-            .setInputShape(melLength * this.melWidth)
-            .setOutputShape(this.words.length)
+            .setInputShape(encodeLength * this.encodeWidth)
+            .setOutputShape(1)
             .load();
-
-        // preallocate the buffers used for posterior smoothing
-        // and argmax used for phrasing, so that we don't do
-        // any allocation within the frame loop
-        this.phraseSum = new float[this.words.length];
-        this.phraseMax = new float[this.words.length];
-        this.phraseArg = new int[phraseLength];
 
         // configure the wakeword activation lengths
         int frameWidth = config.getInteger("frame-width");
+        this.posteriorThreshold = (float) config
+            .getDouble("wake-threshold", (double) DEFAULT_WAKE_THRESHOLD);
         this.minActive = config
             .getInteger("wake-active-min", DEFAULT_WAKE_ACTIVE_MIN)
             / frameWidth;
@@ -351,6 +329,7 @@ public final class WakewordTrigger implements SpeechProcessor {
      */
     public void close() throws Exception {
         this.filterModel.close();
+        this.encodeModel.close();
         this.detectModel.close();
     }
 
@@ -379,10 +358,12 @@ public final class WakewordTrigger implements SpeechProcessor {
                     deactivate(context);
         }
 
-        // always clear detector state on a vad deactivation
-        // this prevents <keyword1><pause><keyword2> detection
-        if (vadFall)
+        // always reset detector state on a vad deactivation
+        if (vadFall) {
+            if (!context.isActive())
+                trace(context);
             reset(context);
+        }
     }
 
     private void sample(SpeechContext context, ByteBuffer buffer) {
@@ -455,101 +436,60 @@ public final class WakewordTrigger implements SpeechProcessor {
         while (this.filterModel.outputs().hasRemaining())
             this.frameWindow.write(this.filterModel.outputs().getFloat());
 
+        encode(context);
+    }
+
+    private void encode(SpeechContext context) {
+        // transfer the mel filterbank window to the encoder model's inputs
+        this.frameWindow.rewind();
+        this.encodeModel.inputs().rewind();
+        while (!this.frameWindow.isEmpty())
+            this.encodeModel.inputs().putFloat(this.frameWindow.read());
+
+        // run the encoder tensorflow model
+        this.encodeModel.run();
+
+        // copy the encoder output into the encode window
+        this.encodeWindow.rewind().seek(this.encodeWidth);
+        while (this.encodeModel.outputs().hasRemaining())
+            this.encodeWindow.write(this.encodeModel.outputs().getFloat());
+
         detect(context);
     }
 
     private void detect(SpeechContext context) {
-        // transfer the mel filterbank window to the detector model's inputs
-        this.frameWindow.rewind();
+        // transfer the encoder window to the detector model's inputs
+        this.encodeWindow.rewind();
         this.detectModel.inputs().rewind();
-        while (!this.frameWindow.isEmpty())
-            this.detectModel.inputs().putFloat(this.frameWindow.read());
+        while (!this.encodeWindow.isEmpty())
+            this.detectModel.inputs().putFloat(this.encodeWindow.read());
 
         // run the classifier tensorflow model
         this.detectModel.run();
 
-        // transfer the classifier's outputs to the posterior smoothing window
-        this.smoothWindow.rewind().seek(this.words.length);
-        while (this.detectModel.outputs().hasRemaining())
-            this.smoothWindow.write(this.detectModel.outputs().getFloat());
-
-        smooth(context);
-    }
-
-    private void smooth(SpeechContext context) {
-        // sum the per-class posteriors across the smoothing window
-        for (int i = 0; i < this.words.length; i++)
-            this.phraseSum[i] = 0;
-        while (!this.smoothWindow.isEmpty())
-            for (int i = 0; i < this.words.length; i++)
-                this.phraseSum[i] += this.smoothWindow.read();
-
-        // compute the posterior mean of each keyword class
-        // write the outputs to the phrasing window
-        int total = this.smoothWindow.capacity() / this.words.length;
-        this.phraseWindow.rewind().seek(this.words.length);
-        for (int i = 0; i < this.words.length; i++)
-            this.phraseWindow.write(this.phraseSum[i] / total);
-
-        phrase(context);
-    }
-
-    private void phrase(SpeechContext context) {
-        // compute the argmax (winning class) of each smoothed output
-        // in the current phrase window
-        for (int i = 0; !this.phraseWindow.isEmpty(); i++) {
-            float max = -Float.MAX_VALUE;
-            for (int j = 0; j < this.words.length; j++) {
-                float value = this.phraseWindow.read();
-                this.phraseMax[j] = Math.max(value, this.phraseMax[j]);
-                if (value > max) {
-                    this.phraseArg[i] = j;
-                    max = value;
-                }
-            }
-        }
-
-        // attempt to find a matching phrase among the argmaxes
-        for (int[] phrase : this.phrases) {
-            // search for any occurrences of the phrase's keywords in order
-            // across the whole phrase window
-            int match = 0;
-            for (int word: this.phraseArg)
-                if (word == phrase[match])
-                    if (++match == phrase.length)
-                        break;
-
-            // if we reached the end of a phrase, we have a match,
-            // so start the activation counter
-            if (match == phrase.length) {
-                activate(context);
-                break;
-            }
-        }
+        // check the classifier's output and activate
+        float posterior = this.detectModel.outputs().getFloat();
+        if (posterior > this.posteriorThreshold)
+            activate(context);
+        if (posterior > this.posteriorMax)
+            this.posteriorMax = posterior;
     }
 
     private void activate(SpeechContext context) {
-        if (!context.isActive()) {
-            trace(context);
-            this.activeLength = 1;
-            context.setActive(true);
-            context.dispatch(SpeechContext.Event.ACTIVATE);
-        }
+        trace(context);
+        this.activeLength = 1;
+        context.setActive(true);
+        context.dispatch(SpeechContext.Event.ACTIVATE);
     }
 
     private void deactivate(SpeechContext context) {
-        if (context.isActive()) {
-            context.setActive(false);
-            context.dispatch(SpeechContext.Event.DEACTIVATE);
-            this.activeLength = 0;
-        }
+        reset(context);
+        context.setActive(false);
+        context.dispatch(SpeechContext.Event.DEACTIVATE);
+        this.activeLength = 0;
     }
 
     private void reset(SpeechContext context) {
-        // trace on vad deactivate without detection
-        if (!context.isActive())
-            trace(context);
-
         // empty the sample buffer, so that only contiguous
         // speech samples are written to it
         this.sampleWindow.reset();
@@ -557,23 +497,19 @@ public final class WakewordTrigger implements SpeechProcessor {
         // reset and fill the other buffers,
         // which prevents them from lagging the detection
         this.frameWindow.reset().fill(0);
-        this.smoothWindow.reset().fill(0);
-        this.phraseWindow.reset().fill(0);
-        Arrays.fill(this.phraseMax, 0);
+        this.encodeWindow.reset().fill(0);
+
+        // reset the encoder states
+        while (this.encodeModel.states().hasRemaining())
+            this.encodeModel.states().putFloat(0);
+
+        // reset the maximum posterior
+        this.posteriorMax = 0;
     }
 
     private void trace(SpeechContext context) {
-        if (context.canTrace(SpeechContext.TraceLevel.INFO)) {
-            StringBuilder message = new StringBuilder();
-            message.append("wake: ");
-            for (int i = 0; i < this.words.length; i++)
-                message.append(
-                    String.format(
-                        "%s=%.2f ",
-                        this.words[i],
-                        this.phraseMax[i]));
-            context.traceInfo(message.toString());
-        }
+        if (context.canTrace(SpeechContext.TraceLevel.INFO))
+            context.traceInfo(String.format("wake: %f", this.posteriorMax));
     }
 
     private float[] hannWindow(int len) {

--- a/src/main/java/com/pylon/spokestack/webrtc/AutomaticGainControl.java
+++ b/src/main/java/com/pylon/spokestack/webrtc/AutomaticGainControl.java
@@ -139,7 +139,7 @@ public class AutomaticGainControl implements SpeechProcessor {
             count++;
         }
 
-        return 20 * Math.log10(Math.max(Math.sqrt(sum / count), 1e-5));
+        return 20 * Math.log10(Math.max(Math.sqrt(sum / count), 2e-5) / 2e-5);
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/com/pylon/spokestack/wakeword/WakewordTriggerTest.java
+++ b/src/test/java/com/pylon/spokestack/wakeword/WakewordTriggerTest.java
@@ -19,7 +19,6 @@ import com.pylon.spokestack.SpeechProcessor;
 import com.pylon.spokestack.tensorflow.TensorflowModel;
 
 public class WakewordTriggerTest {
-
     @Test
     public void testConstruction() throws Exception {
         final SpeechConfig config = new SpeechConfig();
@@ -33,16 +32,13 @@ public class WakewordTriggerTest {
         config
             .put("sample-rate", 16000)
             .put("frame-width", 10)
-            .put("wake-words", "hello")
             .put("wake-filter-path", "filter-path")
+            .put("wake-encode-path", "encode-path")
             .put("wake-detect-path", "detect-path");
         new WakewordTrigger(config, loader);
 
         // valid config
         config
-            .put("wake-phrases", "hello")
-            .put("wake-smooth-length", 300)
-            .put("wake-phrase-length", 500)
             .put("wake-active-min", 500)
             .put("wake-active-max", 5000)
             .put("rms-target", 0.08)
@@ -53,15 +49,6 @@ public class WakewordTriggerTest {
             .put("mel-frame-length", 400)
             .put("mel-frame-width", 40);
         new WakewordTrigger(config, loader);
-
-        // invalid wake phrases
-        config.put("wake-phrases", "goodbye");
-        assertThrows(IllegalArgumentException.class, new Executable() {
-            public void execute() {
-                new WakewordTrigger(config, loader);
-            }
-        });
-        config.put("wake-phrases", "hello");
 
         // invalid fft window size
         config.put("fft-window-size", 513);
@@ -95,6 +82,7 @@ public class WakewordTriggerTest {
         env.process();
 
         verify(env.filter, never()).run();
+        verify(env.encode, never()).run();
         verify(env.detect, never()).run();
 
         assertEquals(null, env.event);
@@ -111,6 +99,7 @@ public class WakewordTriggerTest {
         env.process();
 
         verify(env.filter, atLeast(1)).run();
+        verify(env.encode, atLeast(1)).run();
         verify(env.detect, atLeast(1)).run();
 
         assertEquals(null, env.event);
@@ -139,10 +128,10 @@ public class WakewordTriggerTest {
         TestEnv env = new TestEnv(testConfig());
 
         env.context.setSpeech(true);
-        env.detect.setOutputs(0, 1);
+        env.detect.setOutputs(0);
         env.process();
 
-        env.detect.setOutputs(1, 0);
+        env.detect.setOutputs(1);
         env.process();
 
         assertEquals(SpeechContext.Event.ACTIVATE, env.event);
@@ -155,10 +144,10 @@ public class WakewordTriggerTest {
         TestEnv env = new TestEnv(testConfig());
 
         env.context.setSpeech(true);
-        env.detect.setOutputs(0, 1);
+        env.detect.setOutputs(0);
         env.process();
 
-        env.detect.setOutputs(1, 0);
+        env.detect.setOutputs(1);
         env.process();
 
         env.process();
@@ -175,10 +164,10 @@ public class WakewordTriggerTest {
         TestEnv env = new TestEnv(testConfig());
 
         env.context.setSpeech(true);
-        env.detect.setOutputs(0, 1);
+        env.detect.setOutputs(0);
         env.process();
 
-        env.detect.setOutputs(1, 0);
+        env.detect.setOutputs(1);
         env.process();
 
         env.context.setSpeech(false);
@@ -194,10 +183,10 @@ public class WakewordTriggerTest {
         TestEnv env = new TestEnv(testConfig());
 
         env.context.setSpeech(true);
-        env.detect.setOutputs(0, 1);
+        env.detect.setOutputs(0);
         env.process();
 
-        env.detect.setOutputs(1, 0);
+        env.detect.setOutputs(1);
         env.process();
         env.process();
 
@@ -254,146 +243,16 @@ public class WakewordTriggerTest {
     }
 
     @Test
-    public void testMultiWord() throws Exception {
-        // verify any word can trigger if no phrases configured
-        TestEnv env = new TestEnv(testConfig()
-            .put("wake-words", "up,dog"));
-
-        env.context.setSpeech(true);
-
-        env.detect.setOutputs(0, 1, 0);
-        env.process();
-        env.detect.setOutputs(1, 0, 0);
-        env.process();
-
-        assertEquals(SpeechContext.Event.ACTIVATE, env.event);
-        assertTrue(env.context.isActive());
-        env.context.setActive(false);
-
-        env.detect.setOutputs(0, 0, 1);
-        env.process();
-        env.detect.setOutputs(1, 0, 0);
-        env.process();
-
-        assertEquals(SpeechContext.Event.ACTIVATE, env.event);
-        assertTrue(env.context.isActive());
-    }
-
-    @Test
-    public void testExactPhrase() throws Exception {
-        // verify only the specified phrase is matched if configured
-        TestEnv env = new TestEnv(testConfig()
-            .put("wake-words", "up,dog")
-            .put("wake-phrases", "up dog")
-            .put("wake-phrase-length", 30));
-
-        env.context.setSpeech(true);
-
-        env.detect.setOutputs(0, 0, 1);
-        env.process();
-        env.detect.setOutputs(0, 1, 0);
-        env.process();
-        env.detect.setOutputs(1, 0, 0);
-        env.process();
-
-        assertFalse(env.context.isActive());
-
-        env.detect.setOutputs(0, 1, 0);
-        env.process();
-        env.detect.setOutputs(0, 0, 1);
-        env.process();
-        env.detect.setOutputs(1, 0, 0);
-        env.process();
-
-        assertEquals(SpeechContext.Event.ACTIVATE, env.event);
-        assertTrue(env.context.isActive());
-    }
-
-    @Test
-    public void testWord1PauseWord2() throws Exception {
-        // verify no activation if a vad deactivation occurs between keywords
-        TestEnv env = new TestEnv(testConfig()
-            .put("wake-words", "up,dog")
-            .put("wake-phrases", "up dog")
-            .put("wake-phrase-length", 40));
-
-        env.context.setSpeech(true);
-        env.detect.setOutputs(0, 1, 0);
-        env.process();
-
-        env.context.setSpeech(false);
-        env.process();
-
-        env.context.setSpeech(true);
-        env.detect.setOutputs(0, 0, 1);
-        env.process();
-        env.detect.setOutputs(1, 0, 0);
-        env.process();
-
-        assertFalse(env.context.isActive());
-    }
-
-    @Test
-    public void testWord1WordsWord2() throws Exception {
-        // verify no activation if intermediate words fill the phrase buffer
-        TestEnv env = new TestEnv(testConfig()
-            .put("wake-words", "up,dog,yo")
-            .put("wake-phrases", "up dog")
-            .put("wake-phrase-length", 30));
-
-        env.context.setSpeech(true);
-
-        env.detect.setOutputs(0, 1, 0, 0);
-        env.process();
-        env.detect.setOutputs(0, 0, 0, 1);
-        env.process();
-        env.detect.setOutputs(0, 0, 1, 0);
-        env.process();
-        env.detect.setOutputs(1, 0, 0, 0);
-        env.process();
-
-        assertFalse(env.context.isActive());
-    }
-
-    @Test
-    public void testSmoothing() throws Exception {
-        // verify that detector posteriors are smoothed with moving average
-        TestEnv env = new TestEnv(testConfig()
-            .put("wake-smooth-length", 20));
-
-        env.context.setSpeech(true);
-
-        env.detect.setOutputs(1, 0);
-        env.process();
-        env.detect.setOutputs(0, 0.5f);
-        env.process();
-        env.detect.setOutputs(1, 0);
-        env.process();
-
-        assertFalse(env.context.isActive());
-
-        env.detect.setOutputs(0, 0.5f);
-        env.process();
-        env.detect.setOutputs(0, 0.5f);
-        env.process();
-        env.detect.setOutputs(1, 0);
-        env.process();
-
-        assertEquals(SpeechContext.Event.ACTIVATE, env.event);
-        assertTrue(env.context.isActive());
-    }
-
-    @Test
     public void testTracing() throws Exception {
         // exercise trace events on activation
         TestEnv env = new TestEnv(testConfig()
             .put("trace-level", 0));
 
         env.context.setSpeech(true);
-        env.detect.setOutputs(0, 1);
+        env.detect.setOutputs(0);
         env.process();
 
-        env.detect.setOutputs(1, 0);
+        env.detect.setOutputs(1);
         env.process();
 
         assertTrue(env.context.getMessage() != null);
@@ -409,11 +268,11 @@ public class WakewordTriggerTest {
             .put("fft-window-size", 160)
             .put("mel-frame-length", 40)
             .put("mel-frame-width", 40)
-            .put("wake-words", "hello")
             .put("wake-filter-path", "filter-path")
+            .put("wake-encode-path", "encode-path")
             .put("wake-detect-path", "detect-path")
-            .put("wake-smooth-length", 10)
-            .put("wake-phrase-length", 20)
+            .put("wake-encode-length", 1000)
+            .put("wake-encode-width", 128)
             .put("wake-active-min", 20)
             .put("wake-active-max", 30);
     }
@@ -438,6 +297,7 @@ public class WakewordTriggerTest {
     public class TestEnv implements OnSpeechEventListener {
         public final TensorflowModel.Loader loader;
         public final TestModel filter;
+        public final TestModel encode;
         public final TestModel detect;
         public final ByteBuffer frame;
         public final WakewordTrigger wake;
@@ -453,11 +313,13 @@ public class WakewordTriggerTest {
             int hopLength = config.getInteger("fft-hop-length");
             int melLength = config.getInteger("mel-frame-length") * sampleRate / 1000 / hopLength;
             int melWidth = config.getInteger("mel-frame-width");
-            String[] words = config.getString("wake-words").split(",");
+            int encodeLength = config.getInteger("wake-encode-length") * sampleRate / 1000 / hopLength;
+            int encodeWidth = config.getInteger("wake-encode-width");
 
             // create/mock tensorflow-lite models
             this.loader = spy(TensorflowModel.Loader.class);
             this.filter = mock(TestModel.class);
+            this.encode = mock(TestModel.class);
             this.detect = mock(TestModel.class);
 
             doReturn(ByteBuffer
@@ -471,14 +333,30 @@ public class WakewordTriggerTest {
             doReturn(ByteBuffer
                         .allocateDirect(melLength * melWidth * 4)
                         .order(ByteOrder.nativeOrder()))
+                .when(this.encode).inputs();
+            doReturn(ByteBuffer
+                        .allocateDirect(encodeWidth * 4)
+                        .order(ByteOrder.nativeOrder()))
+                .when(this.encode).states();
+            doReturn(ByteBuffer
+                        .allocateDirect(encodeWidth * 4)
+                        .order(ByteOrder.nativeOrder()))
+                .when(this.encode).outputs();
+            doReturn(ByteBuffer
+                        .allocateDirect(encodeLength * encodeWidth * 4)
+                        .order(ByteOrder.nativeOrder()))
                 .when(this.detect).inputs();
             doReturn(ByteBuffer
-                        .allocateDirect((words.length + 1) * 4)
+                        .allocateDirect(1 * 4)
                         .order(ByteOrder.nativeOrder()))
                 .when(this.detect).outputs();
             doCallRealMethod().when(this.filter).run();
+            doCallRealMethod().when(this.encode).run();
             doCallRealMethod().when(this.detect).run();
-            doReturn(this.filter).doReturn(this.detect).when(this.loader).load();
+            doReturn(this.filter)
+                .doReturn(this.encode)
+                .doReturn(this.detect)
+                .when(this.loader).load();
 
             // create the frame buffer and wakeword trigger
             this.frame = ByteBuffer.allocateDirect(frameWidth * sampleRate / 1000 * 2);


### PR DESCRIPTION
These changes introduce a new tensorflow "encode" model in the wakeword trigger, which allows us to implement autoregressive models for wakeword detection (like rnns and attention). Doing this efficiently requires running each frame through the encoder and then aggregating these frames for attention/classification, in order to avoid redundant calls to the encoder. These models also provide the ability to detect whole phrases with long-range frame dependencies, so we no longer need manual phrasing or smoothing logic and buffers.

This design supports stateful autoregression models (GRU, LSTM, etc.) by maintaining an input/output `state` tensor on the tensorflow model object. CRNN-based encoders with sliding window inputs are also supported, since the mel frames are still maintained in a ring buffer, although the default is now to send a single frame at a time to the encoder.

For an example model, see https://arxiv.org/abs/1803.10916.
