### PR TITLE
reset activation timeout on manual deactivation

### DIFF
--- a/src/main/java/com/pylon/spokestack/wakeword/WakewordTrigger.java
+++ b/src/main/java/com/pylon/spokestack/wakeword/WakewordTrigger.java
@@ -349,6 +349,7 @@ public final class WakewordTrigger implements SpeechProcessor {
         if (!context.isActive()) {
             // run the current frame through the detector pipeline
             // activate if a keyword phrase was detected
+            this.activeLength = 0;
             sample(context, buffer);
         } else {
             // continue this wakeword (or external) activation
@@ -477,7 +478,6 @@ public final class WakewordTrigger implements SpeechProcessor {
 
     private void activate(SpeechContext context) {
         trace(context);
-        this.activeLength = 1;
         context.setActive(true);
         context.dispatch(SpeechContext.Event.ACTIVATE);
     }
@@ -486,7 +486,6 @@ public final class WakewordTrigger implements SpeechProcessor {
         reset(context);
         context.setActive(false);
         context.dispatch(SpeechContext.Event.DEACTIVATE);
-        this.activeLength = 0;
     }
 
     private void reset(SpeechContext context) {

--- a/src/test/java/com/pylon/spokestack/wakeword/WakewordTriggerTest.java
+++ b/src/test/java/com/pylon/spokestack/wakeword/WakewordTriggerTest.java
@@ -149,6 +149,7 @@ public class WakewordTriggerTest {
 
         env.detect.setOutputs(1);
         env.process();
+        env.process();
 
         env.process();
         env.process();
@@ -187,6 +188,7 @@ public class WakewordTriggerTest {
         env.process();
 
         env.detect.setOutputs(1);
+        env.process();
         env.process();
         env.process();
 


### PR DESCRIPTION
Previously, the wakeword trigger would only reset its activation counter whenever it automatically deactivated the pipeline, due to either a timeout or a vad deactivation. However, if the client manually deactivated the pipeline, the counter's state would be retained for the subsequent activation. This would shorten that activation's effective timeout. These changes reset the activation counter whenever the pipeline is inactive.